### PR TITLE
Test: PR preview build

### DIFF
--- a/.github/workflows/pr-preview-build.yml
+++ b/.github/workflows/pr-preview-build.yml
@@ -44,13 +44,15 @@ jobs:
         env:
           PR_NUMBER: ${{ github.event.number }}
           PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_SHA_FULL: ${{ github.event.pull_request.head.sha }}
         run: |
           # Derive the host from docs/CNAME so this works on both the production
           # repo (docs.3dcitydb.org) and the bwibo testing fork
           # (docs.brunowillenborg.de) without any change.
           HOST="$(tr -d '[:space:]' < docs/CNAME 2>/dev/null || echo docs.3dcitydb.org)"
           export SITE_URL="https://${HOST}/pr/${PR_NUMBER}/"
-          echo "Building preview at $SITE_URL"
+          export PR_SHA="${PR_SHA_FULL:0:7}"
+          echo "Building preview at $SITE_URL (commit $PR_SHA)"
           mkdocs build -f mkdocs.pr.yml -d site --strict
 
       - name: Record PR metadata for deploy job

--- a/.github/workflows/pr-preview-build.yml
+++ b/.github/workflows/pr-preview-build.yml
@@ -1,0 +1,70 @@
+name: Build PR preview
+
+# Builds a documentation preview for a pull request. This job runs with a
+# read-only token and NEVER touches the gh-pages branch, so it is safe even for
+# untrusted (fork) PRs. The actual publish happens in the companion workflow
+# "Deploy PR preview" (pr-preview-deploy.yml), which runs with a write token via
+# workflow_run. This build/deploy split lets us support fork PRs in the future
+# by simply relaxing the same-repo guard below.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+# Only build PRs from the same repository for now. Fork PRs could inject content
+# into the published docs, so they are intentionally excluded. Remove this guard
+# (and review the trust model) to enable previews for forks later.
+permissions:
+  contents: read
+
+concurrency:
+  # Supersede in-flight builds for the same PR.
+  group: pr-preview-${{ github.event.number }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install dependencies
+        run: pip install -U -r requirements.txt
+
+      - name: Build PR preview
+        env:
+          PR_NUMBER: ${{ github.event.number }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: |
+          # Derive the host from docs/CNAME so this works on both the production
+          # repo (docs.3dcitydb.org) and the bwibo testing fork
+          # (docs.brunowillenborg.de) without any change.
+          HOST="$(tr -d '[:space:]' < docs/CNAME 2>/dev/null || echo docs.3dcitydb.org)"
+          export SITE_URL="https://${HOST}/pr/${PR_NUMBER}/"
+          echo "Building preview at $SITE_URL"
+          mkdocs build -f mkdocs.pr.yml -d site --strict
+
+      - name: Record PR metadata for deploy job
+        run: |
+          echo "${{ github.event.number }}" > pr_number.txt
+          echo "${{ github.event.pull_request.head.sha }}" > pr_sha.txt
+
+      - name: Upload preview artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr-preview
+          path: |
+            site
+            pr_number.txt
+            pr_sha.txt
+          retention-days: 3
+          if-no-files-found: error

--- a/.github/workflows/pr-preview-cleanup.yml
+++ b/.github/workflows/pr-preview-cleanup.yml
@@ -1,0 +1,73 @@
+name: Cleanup PR previews
+
+# Weekly sweep that removes pr/<num>/ preview folders from gh-pages whose pull
+# request is no longer open (closed, merged, or deleted). Runs on a schedule
+# only; there is no on-close trigger by design.
+
+on:
+  schedule:
+    - cron: "0 3 * * 1" # Mondays 03:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: read
+
+concurrency:
+  # Shared with ci.yml and pr-preview-deploy.yml to avoid racing on gh-pages.
+  group: docs-deploy
+  cancel-in-progress: false
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout gh-pages
+        uses: actions/checkout@v5
+        with:
+          ref: gh-pages
+
+      - name: Remove previews of closed/merged PRs
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          if [ ! -d pr ]; then
+            echo "No pr/ directory; nothing to clean."
+            exit 0
+          fi
+          removed=0
+          for dir in pr/*/; do
+            [ -d "$dir" ] || continue
+            num="$(basename "$dir")"
+            if ! [[ "$num" =~ ^[0-9]+$ ]]; then
+              echo "Skipping non-numeric entry: $dir"
+              continue
+            fi
+            # Treat any non-OPEN state, or a PR that no longer exists, as stale.
+            state="$(gh pr view "$num" --json state -q .state 2>/dev/null || echo MISSING)"
+            if [ "$state" = "OPEN" ]; then
+              echo "PR #$num is open; keeping preview."
+            else
+              echo "PR #$num is $state; removing $dir"
+              rm -rf "$dir"
+              removed=$((removed + 1))
+            fi
+          done
+          echo "Removed $removed preview(s)."
+
+      - name: Commit and push if changed
+        run: |
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
+          git add -A
+          if git diff --cached --quiet; then
+            echo "No stale previews to remove."
+            exit 0
+          fi
+          git commit -m "docs: clean up previews of closed/merged PRs"
+          git push origin gh-pages || {
+            git fetch origin gh-pages
+            git rebase origin/gh-pages
+            git push origin gh-pages
+          }

--- a/.github/workflows/pr-preview-deploy.yml
+++ b/.github/workflows/pr-preview-deploy.yml
@@ -1,0 +1,119 @@
+name: Deploy PR preview
+
+# Publishes the artifact produced by "Build PR preview" into pr/<num>/ on the
+# gh-pages branch and posts/updates a preview link on the PR. This runs via
+# workflow_run so it has a write token even though the build job did not — the
+# build job never sees secrets, which keeps the door open for fork PRs later.
+#
+# This job only copies the already-built static site into gh-pages; it never
+# executes PR code. It also NEVER touches versions.json, so PR previews do not
+# appear in the mike version menu.
+
+on:
+  workflow_run:
+    workflows: ["Build PR preview"]
+    types: [completed]
+
+permissions:
+  contents: write
+  pull-requests: write
+  actions: read # required to download the build artifact from the triggering run
+
+concurrency:
+  # Shared with ci.yml (mike deploys) and the cleanup workflow so that no two
+  # jobs push to gh-pages at the same time.
+  group: docs-deploy
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download preview artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: pr-preview
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path: artifact
+
+      - name: Read PR metadata
+        id: meta
+        run: |
+          PR="$(cat artifact/pr_number.txt)"
+          SHA="$(cat artifact/pr_sha.txt)"
+          # Harden against a tampered artifact: PR number must be digits only.
+          if ! [[ "$PR" =~ ^[0-9]+$ ]]; then
+            echo "Invalid PR number: '$PR'" >&2
+            exit 1
+          fi
+          # Use the host the site was actually built with (from its CNAME) so the
+          # comment link is correct on both the production repo and the fork.
+          HOST="$(tr -d '[:space:]' < artifact/site/CNAME 2>/dev/null || echo docs.3dcitydb.org)"
+          echo "pr=$PR" >> "$GITHUB_OUTPUT"
+          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
+          echo "host=$HOST" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout gh-pages
+        uses: actions/checkout@v5
+        with:
+          ref: gh-pages
+          path: gh-pages
+
+      - name: Update preview folder
+        run: |
+          PR="${{ steps.meta.outputs.pr }}"
+          rm -rf "gh-pages/pr/$PR"
+          mkdir -p "gh-pages/pr/$PR"
+          cp -r artifact/site/. "gh-pages/pr/$PR/"
+
+      - name: Commit and push
+        run: |
+          cd gh-pages
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
+          git add "pr/${{ steps.meta.outputs.pr }}"
+          if git diff --cached --quiet; then
+            echo "No changes to publish."
+            exit 0
+          fi
+          git commit -m "docs: preview for PR #${{ steps.meta.outputs.pr }} (${{ steps.meta.outputs.sha }})"
+          # Serialized by the docs-deploy concurrency group; rebase is a safety net.
+          git push origin gh-pages || {
+            git fetch origin gh-pages
+            git rebase origin/gh-pages
+            git push origin gh-pages
+          }
+
+      - name: Comment preview link on PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = Number('${{ steps.meta.outputs.pr }}');
+            const sha = '${{ steps.meta.outputs.sha }}';
+            const host = '${{ steps.meta.outputs.host }}';
+            const url = `https://${host}/pr/${pr}/`;
+            const marker = '<!-- pr-preview-bot -->';
+            const body = [
+              marker,
+              '### 📖 Documentation preview ready',
+              '',
+              'Preview for this PR is live at:',
+              `**${url}**`,
+              '',
+              `Built from ${sha}. Updated automatically on every push. ` +
+              'Removed automatically after the PR is closed.',
+            ].join('\n');
+            const { owner, repo } = context.repo;
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner, repo, issue_number: pr, per_page: 100,
+            });
+            const existing = comments.find(c => c.body && c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number: pr, body });
+            }

--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,1 +1,1 @@
-docs.3dcitydb.org
+docs.brunowillenborg.de

--- a/docs/citydb-tool/export-config.md
+++ b/docs/citydb-tool/export-config.md
@@ -249,6 +249,7 @@ The JSON structure for storing write options is shown below. Format-specific set
 | [`"tempDirectory"`](export.md#controlling-the-export-process)   | Store temporary files in this directory.          |               |
 | [`"encoding"`](export.md#specifying-the-output-file)            | Encoding to use for the output file.              |               |
 | [`"srsName"`](export.md#reprojecting-geometries)                | Name of the CRS to use in the output file.        |               |
+| [`"skipEmptyTiles"`](export.md#handling-empty-tiles)            | Skip tile files containing no exported features.  |               |
 
 ### CityGML options
 

--- a/docs/citydb-tool/export-config.md
+++ b/docs/citydb-tool/export-config.md
@@ -232,6 +232,7 @@ The JSON structure for storing write options is shown below. Format-specific set
     "tempDirectory": "/path/to/temp",
     "encoding": "UTF-8",
     "srsName": "http://www.opengis.net/def/crs/EPSG/0/25832",
+    "skipEmptyTiles": false,
     "formatOptions": {
       "CityGML": {...},
       "CityJSON": {...}
@@ -249,7 +250,7 @@ The JSON structure for storing write options is shown below. Format-specific set
 | [`"tempDirectory"`](export.md#controlling-the-export-process)   | Store temporary files in this directory.          |               |
 | [`"encoding"`](export.md#specifying-the-output-file)            | Encoding to use for the output file.              |               |
 | [`"srsName"`](export.md#reprojecting-geometries)                | Name of the CRS to use in the output file.        |               |
-| [`"skipEmptyTiles"`](export.md#handling-empty-tiles)            | Skip tile files containing no exported features.  |               |
+| [`"skipEmptyTiles"`](export.md#handling-empty-tiles)            | Skip tile files containing no exported features.  | `false`       |
 
 ### CityGML options
 

--- a/docs/citydb-tool/export.md
+++ b/docs/citydb-tool/export.md
@@ -462,6 +462,12 @@ Some common examples include:
 - `%.2f`: Formats the value as a decimal number with two decimal places.
 - `%4.4s`: Formats the value as a string, but only prints exactly four characters.
 
+#### Handling empty tiles
+
+By default, citydb-tool generates output files for all tiles in the tile grid, including tiles without exported
+features. Use the `--skip-empty-tiles` option to omit empty tiles from the output. When enabled, only files for tiles
+containing exported features are retained, reducing the number of generated files and saving disk space.
+
 #### Tiled export example
 
 The following command exports all roads from the 3DCityDB, organizing them into 2x2 km tiles. The tiling extent is

--- a/docs/index.md
+++ b/docs/index.md
@@ -92,3 +92,4 @@ We are happy for any feedback or contribution we can use to improve 3DCityDB, it
 ## Legacy documentation
 
 The legacy documentation of the 3D City Database `v4` is available here: <https://3dcitydb-docs.readthedocs.io/>
+<!-- PR preview test trigger -->

--- a/docs/index.md
+++ b/docs/index.md
@@ -93,3 +93,4 @@ We are happy for any feedback or contribution we can use to improve 3DCityDB, it
 
 The legacy documentation of the 3D City Database `v4` is available here: <https://3dcitydb-docs.readthedocs.io/>
 <!-- PR preview test trigger -->
+<!-- second trigger -->

--- a/mkdocs.pr.yml
+++ b/mkdocs.pr.yml
@@ -1,0 +1,20 @@
+# PR preview build config #####################################################
+# Overlay used ONLY for per-PR preview builds (see .github/workflows/
+# pr-preview-build.yml). It inherits the production mkdocs.yml and overrides
+# just the bits a throwaway preview needs. Do not use this for real deploys.
+INHERIT: mkdocs.yml
+
+# Per-PR values are injected by CI via environment variables.
+site_url: !ENV [SITE_URL, "https://docs.3dcitydb.org/"]
+
+theme:
+  # Only PR builds pull in the preview banner override.
+  custom_dir: overrides
+
+extra:
+  pr_number: !ENV [PR_NUMBER, ""]
+  pr_url: !ENV [PR_URL, ""]
+  # Hide the mike version selector in previews: there is no versions.json
+  # under /pr/<num>/, so a selector would be broken. Replacing the dict from
+  # mkdocs.yml with `false` makes Material render no version dropdown.
+  version: false

--- a/mkdocs.pr.yml
+++ b/mkdocs.pr.yml
@@ -14,6 +14,7 @@ theme:
 extra:
   pr_number: !ENV [PR_NUMBER, ""]
   pr_url: !ENV [PR_URL, ""]
+  pr_sha: !ENV [PR_SHA, ""]
   # Hide the mike version selector in previews: there is no versions.json
   # under /pr/<num>/, so a selector would be broken. Replacing the dict from
   # mkdocs.yml with `false` makes Material render no version dropdown.

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -1,0 +1,22 @@
+{% extends "base.html" %}
+
+<!--
+  PR preview banner. Only active when built with mkdocs.pr.yml (which sets
+  theme.custom_dir: overrides and extra.pr_number). Production builds never
+  use this template, so the official docs are unaffected.
+-->
+
+{% block announce %}
+  {% if config.extra.pr_number %}
+  <a href="{{ config.extra.pr_url }}" style="font-weight: 600;">
+    🔍 Preview of pull request #{{ config.extra.pr_number }} — not the official documentation.
+  </a>
+  {% endif %}
+{% endblock %}
+
+{% block extrahead %}
+  {{ super() }}
+  {% if config.extra.pr_number %}
+  <meta name="robots" content="noindex, nofollow">
+  {% endif %}
+{% endblock %}

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -9,7 +9,7 @@
 {% block announce %}
   {% if config.extra.pr_number %}
   <a href="{{ config.extra.pr_url }}" style="font-weight: 600;">
-    🔍 Preview of pull request #{{ config.extra.pr_number }} — not the official documentation.
+    🔍 Preview of pull request #{{ config.extra.pr_number }}{% if config.extra.pr_sha %} (commit {{ config.extra.pr_sha }}){% endif %} — not the official documentation.
   </a>
   {% endif %}
 {% endblock %}

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,43 @@
+# PR preview tests
+
+Lightweight tests for the per-PR documentation preview feature.
+
+> **Scope:** these tests live **only on the `bwibo` testing fork**
+> (`BWibo/3dcitydb-mkdocs`, served at `docs.brunowillenborg.de`). They are **not**
+> merged to `origin` — keep them on a separate `test-*` branch / commit that stays off
+> the upstream PR. The feature code (workflows, `mkdocs.pr.yml`, `overrides/`) is what
+> merges to `origin`.
+
+## `pr_build_test.sh` — local build contract
+
+Builds the preview exactly as CI does and asserts the output contract (banner, `noindex`,
+no version selector). No deployment needed.
+
+```bash
+bash tests/pr_build_test.sh
+# override the simulated PR:
+PR_NUMBER=123 bash tests/pr_build_test.sh
+```
+
+Requires the doc toolchain from `requirements.txt` (`mkdocs`, `mike`, plugins) on `PATH`.
+
+## `smoke_test.sh` — deployed preview
+
+Checks a live preview after the deploy workflow has run on the testing deployment:
+
+```bash
+bash tests/smoke_test.sh <pr-number>
+# against a different host:
+bash tests/smoke_test.sh <pr-number> https://docs.brunowillenborg.de
+```
+
+Asserts the preview URL returns 200 with the banner + `noindex`, and that the root
+`versions.json` does **not** list the PR (the version menu stays unaffected).
+
+## Suggested end-to-end run on `bwibo`
+
+1. Push the feature branch to `bwibo` and open a PR there.
+2. Watch **Build PR preview** → **Deploy PR preview**; confirm the bot comment appears.
+3. `bash tests/smoke_test.sh <pr#>`.
+4. Close the PR, run **Cleanup PR previews** via *workflow_dispatch*, and confirm
+   `https://docs.brunowillenborg.de/pr/<pr#>/` now returns 404.

--- a/tests/pr_build_test.sh
+++ b/tests/pr_build_test.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+#
+# Local build-contract test for the per-PR documentation preview.
+#
+# Runs the exact build the CI does (mkdocs.pr.yml + the PR_* env vars) and
+# asserts the preview contract, without deploying anything:
+#   - the build succeeds
+#   - the preview banner (PR number + URL) is rendered
+#   - the page is marked noindex
+#   - the mike version selector / versions.json reference is absent
+#
+# Kept only on the `bwibo` testing fork (docs.brunowillenborg.de); not merged
+# to origin. Run from the repo root:
+#
+#   bash tests/pr_build_test.sh
+#
+set -euo pipefail
+
+PR_NUMBER="${PR_NUMBER:-999}"
+PR_URL="${PR_URL:-https://github.com/BWibo/3dcitydb-mkdocs/pull/${PR_NUMBER}}"
+SITE_URL="${SITE_URL:-https://docs.brunowillenborg.de/pr/${PR_NUMBER}/}"
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+OUT="$(mktemp -d)"
+trap 'rm -rf "$OUT"' EXIT
+
+cd "$REPO_ROOT"
+
+echo "==> Building PR preview (PR #${PR_NUMBER}) into ${OUT}"
+SITE_URL="$SITE_URL" PR_NUMBER="$PR_NUMBER" PR_URL="$PR_URL" \
+  mkdocs build -f mkdocs.pr.yml -d "$OUT" --strict
+
+INDEX="$OUT/index.html"
+
+fail=0
+assert_contains() { # <file> <needle> <message>
+  if grep -qF "$2" "$1"; then
+    echo "  PASS: $3"
+  else
+    echo "  FAIL: $3"
+    fail=1
+  fi
+}
+assert_absent() { # <file> <needle> <message>
+  if grep -qF "$2" "$1"; then
+    echo "  FAIL: $3"
+    fail=1
+  else
+    echo "  PASS: $3"
+  fi
+}
+
+echo "==> Asserting preview contract on ${INDEX}"
+assert_contains "$INDEX" "Preview of pull request #${PR_NUMBER}" "banner shows PR number"
+assert_contains "$INDEX" "$PR_URL" "banner links to the PR"
+assert_contains "$INDEX" 'name="robots" content="noindex, nofollow"' "page is noindex"
+assert_absent   "$INDEX" "md-version" "no version selector markup"
+assert_absent   "$INDEX" "versions.json" "no versions.json reference"
+
+if [ "$fail" -ne 0 ]; then
+  echo "==> RESULT: FAILED"
+  exit 1
+fi
+echo "==> RESULT: PASSED"

--- a/tests/smoke_test.sh
+++ b/tests/smoke_test.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+#
+# Deployed-preview smoke test for the per-PR documentation preview.
+#
+# Checks a live preview on the testing deployment (docs.brunowillenborg.de):
+#   - /pr/<num>/ returns HTTP 200
+#   - the preview banner and noindex are present in the served HTML
+#   - the root versions.json does NOT list the PR (version menu unaffected)
+#
+# Kept only on the `bwibo` testing fork; not merged to origin. Usage:
+#
+#   bash tests/smoke_test.sh <pr-number> [base-url]
+#
+# Defaults base-url to https://docs.brunowillenborg.de
+set -euo pipefail
+
+PR_NUMBER="${1:?usage: smoke_test.sh <pr-number> [base-url]}"
+BASE_URL="${2:-https://docs.brunowillenborg.de}"
+BASE_URL="${BASE_URL%/}"
+
+PREVIEW_URL="${BASE_URL}/pr/${PR_NUMBER}/"
+VERSIONS_URL="${BASE_URL}/versions.json"
+
+fail=0
+
+echo "==> GET ${PREVIEW_URL}"
+code="$(curl -s -o /dev/null -w '%{http_code}' "$PREVIEW_URL")"
+if [ "$code" = "200" ]; then
+  echo "  PASS: preview returns 200"
+else
+  echo "  FAIL: preview returned HTTP $code"
+  fail=1
+fi
+
+html="$(curl -s "$PREVIEW_URL")"
+if grep -qF "Preview of pull request #${PR_NUMBER}" <<<"$html"; then
+  echo "  PASS: banner present in served HTML"
+else
+  echo "  FAIL: banner missing in served HTML"
+  fail=1
+fi
+if grep -qF 'name="robots" content="noindex, nofollow"' <<<"$html"; then
+  echo "  PASS: served page is noindex"
+else
+  echo "  FAIL: served page missing noindex"
+  fail=1
+fi
+
+echo "==> GET ${VERSIONS_URL} (PR must be absent)"
+versions="$(curl -s "$VERSIONS_URL")"
+if grep -qF "\"pr/${PR_NUMBER}\"" <<<"$versions" || grep -qF "\"${PR_NUMBER}\"" <<<"$versions"; then
+  echo "  FAIL: versions.json unexpectedly references the PR"
+  fail=1
+else
+  echo "  PASS: versions.json does not list the PR (menu unaffected)"
+fi
+
+if [ "$fail" -ne 0 ]; then
+  echo "==> RESULT: FAILED"
+  exit 1
+fi
+echo "==> RESULT: PASSED"


### PR DESCRIPTION
Throwaway PR to exercise the per-PR documentation preview feature (build → deploy → bot comment). Safe to close/delete after testing.